### PR TITLE
Removed duplicate ObjectManager::find reference

### DIFF
--- a/doctrine/common/.ide-toolbox.metadata.json
+++ b/doctrine/common/.ide-toolbox.metadata.json
@@ -5,7 +5,6 @@
             "provider": "doctrine.models",
             "signature": [
                 "Doctrine\\Common\\Persistence\\ManagerRegistry::getManagerForClass",
-                "Doctrine\\Common\\Persistence\\ObjectManager::find",
                 "Doctrine\\Common\\Persistence\\ObjectManager::getClassMetadata",
                 "Doctrine\\Common\\Persistence\\ObjectManager::getRepository"
             ],


### PR DESCRIPTION
_see changes_

I think this was the reason, why every ORM class gets listed twice in the completion list.
