### PR TITLE
Add header completion for php-http/message-factory

### DIFF
--- a/php-http/message-factory/.ide-toolbox.metadata.json
+++ b/php-http/message-factory/.ide-toolbox.metadata.json
@@ -1,0 +1,47 @@
+{
+    "registrar": [
+        {
+            "provider": "http_methods",
+            "language": "php",
+            "signature": [
+                "Http\\Message\\RequestFactory::createRequest"
+            ]
+        },
+        {
+            "provider": "http_request_headers",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "Http\\Message\\RequestFactory",
+                    "method": "createRequest",
+                    "index": 2,
+                    "type": "array_key"
+                }
+            ]
+        },
+        {
+            "provider": "http_response_headers",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "Http\\Message\\ResponseFactory",
+                    "method": "createResponse",
+                    "index": 2,
+                    "type": "array_key"
+                }
+            ]
+        },
+        {
+            "provider": "content_types",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "Http\\Message\\RequestFactory",
+                    "method": "createRequest",
+                    "index": 2,
+                    "array": "Content-Type"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows people using HTTPlug to have completion for headers for the initial request creation (completion for mutation depends on the PSR-7 support in #14 as these factories are creating PSR-7 objects)