### PR TITLE
Add PSR-11 ContainerInterface support / Zend\ServiceManager

### DIFF
--- a/psr/container/.ide-toolbox.metadata.json
+++ b/psr/container/.ide-toolbox.metadata.json
@@ -1,0 +1,15 @@
+{
+    "registrar": [
+        {
+            "provider": "class",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "Psr\\Container\\ContainerInterface",
+                    "method": "get",
+                    "type": "type"
+                }
+            ]
+        }
+    ]
+}

--- a/zend/service-manager/.ide-toolbox.metadata.json
+++ b/zend/service-manager/.ide-toolbox.metadata.json
@@ -1,0 +1,15 @@
+{
+    "registrar": [
+        {
+            "provider": "class",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "Zend\\ServiceManager\\ServiceLocatorInterface",
+                    "method": "get",
+                    "type": "type"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds return type detection for `Psr\Container\ContainerInterface`-style service locators.

```
$thing = $container->get(\MyApp\MyThing::class);
// $thing is type of \MyApp\MyThing
```

As discussed a while ago on twitter: https://gist.github.com/Haehnchen/aea3ac2d10cc709227815436de1e2ba2

This is especially useful for ZF3/Zend Expressive style Factories:

```
use Zend\ServiceManager\Factory\FactoryInterface;
use Psr\Container\ContainerInterface;

class MyObjectFactory implements FactoryInterface
{
    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
    {
        $dependency = $container->get(stdClass::class);
        return new MyObject($dependency);
    }
}
```

