### PR TITLE
Added completion for Symfony Templating escaper contexts

### DIFF
--- a/symfony/templating/.ide-toolbox.metadata.json
+++ b/symfony/templating/.ide-toolbox.metadata.json
@@ -1,0 +1,22 @@
+{
+    "registrar": [
+        {
+            "provider": "symfony_templating_escapers",
+            "language": "php",
+            "signature": [
+                "Symfony\\Component\\Templating\\PhpEngine:getEscaper",
+                "Symfony\\Component\\Templating\\PhpEngine:setEscaper",
+                "Symfony\\Component\\Templating\\PhpEngine:escape:1"
+            ]
+        }
+    ],
+    "providers": [
+        {
+            "name": "symfony_templating_escapers",
+            "lookup_strings": [
+                "html",
+                "js"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Useful in PHP templates:

```php
/** @var PhpEngine $view */
$view->escape($foo, '<CARET>');
```
`html` and `js` contexts are available by default in Templating component:
https://symfony.com/doc/current/components/templating.html#output-escaping